### PR TITLE
third argument on access of in rtw android c filled with cero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository branch is deprecated and is no longer being updated.
+
 # rtl8723de
 Realtek RTL8723DE module for Linux kernel version >= 5.0
 

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -632,7 +632,7 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 	* post 5.0.0 ==> static inline int access_ok(const void *addr, unsigned long size)
 	* type int was a previously unused variable 
 	*/
-	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len),0) {
 		RTW_INFO("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
I compile it with this modification and the folowwing command after running dkms add  command, then run the make and make install lines, resulting the driver to work fine, now in debian 10 the wireless hardware work OK